### PR TITLE
Fix compilation issues on Haxe 4+

### DIFF
--- a/cli_test/ParserTest.hx
+++ b/cli_test/ParserTest.hx
@@ -3,12 +3,12 @@ import haxetoml.*;
 
 class ParserTest {
 	static function main() {
-		var filename = Sys.args()[0];
+		var filename = Sys.args()[0] ?? "harder.toml";
         var defaultValue = {
             title: "Default Title",
             description: "Default Description Text"
         };
-		var parsedToml = TomlParser.parseFile('resources/test_files/$filename.toml', defaultValue);
+		var parsedToml = TomlParser.parseFile('resources/test_files/$filename', defaultValue);
 		trace(parsedToml);
 	}
 }

--- a/src/haxetoml/TomlParser.hx
+++ b/src/haxetoml/TomlParser.hx
@@ -26,7 +26,7 @@ class TomlParser {
 	var	root : Dynamic;
 	var pos = 0;
 
-	public var currentToken(get_currentToken, null) : Token;
+	public var currentToken(get, null):Token;
 
 	/** Set up a new TomlParser instance */
 	public function new() {}

--- a/src/haxetoml/TomlParser.hx
+++ b/src/haxetoml/TomlParser.hx
@@ -366,11 +366,8 @@ class TomlParser {
 		return (new TomlParser()).parse(toml, defaultValue);
 	}
 
-	#if (neko || php || cpp)
-		/** Static shortcut method to read toml file and parse into Dynamic object.  Available on Neko, PHP and CPP. */
-		public static function parseFile(filename: String, ?defaultValue: Dynamic)
-		{
-			return parseString(sys.io.File.getContent(filename), defaultValue);
-		}
-	#end
+	/** Static shortcut method to read toml file and parse into Dynamic object */
+	public static function parseFile(filename:String, ?defaultValue:Dynamic) {
+		return parseString(sys.io.File.getContent(filename), defaultValue);
+	}
 }

--- a/src/haxetoml/TomlParser.hx
+++ b/src/haxetoml/TomlParser.hx
@@ -1,6 +1,5 @@
 package haxetoml;
 
-using haxe.Utf8;
 using Lambda;
 
 private enum TokenType {
@@ -237,24 +236,24 @@ class TomlParser {
 		return decode(token, TokenType.TkKey, function(v) { return v; });
 	}
 
-	function unescape(str : String) {
+	function unescape(str:UnicodeString) {
 		var pos = 0;
-		var buf = new haxe.Utf8();
+		var buf = new StringBuf();
 
-		var len = Utf8.length(str);
-		while(pos < len) {
-			var c = Utf8.charCodeAt(str, pos);
+		var len = str.length;
+		while (pos < len) {
+			var c = str.charCodeAt(pos);
 
 			// strip first and last quotation marks
-			if ((pos == 0 || pos == len-1) && c == "\"".code) {
+			if ((pos == 0 || pos == len - 1) && c == "\"".code) {
 				pos++;
 				continue;
 			}
 
 			pos++;
 
-			if(c == "\\".code) {
-				c = Utf8.charCodeAt(str, pos);
+			if (c == "\\".code) {
+				c = str.charCodeAt(pos);
 				pos++;
 
 				switch(c) {
@@ -265,7 +264,7 @@ class TomlParser {
 					case "f".code: buf.addChar(12);
 					case "/".code, "\\".code, "\"".code: buf.addChar(c);
 					case "u".code:
-						var uc = Std.parseInt("0x" + Utf8.sub(str, pos, 4));
+						var uc = Std.parseInt("0x" + str.substr(pos, 4));
 						buf.addChar(uc);
 						pos += 4;
 					default:


### PR DESCRIPTION
This PR contains a few minor fixes that makes the library work with Haxe 4+.

- Fix inline accessor name
- Fix deprecation warnings regarding the `Utf8` class - `UnicodeString` and `StringBuf` are used instead.
- Allow the user to parse a file from all targets. 

Would you be interested in adding a `haxelib.json` file to this repository? I believe this library is still useful, even if it doesn't cover the latest TOML versions.